### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,71 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 ---
+## [0.1.0] - 2025-07-31
+
+### 🚀 Features
+
+- 🎸 list directories - ([86dbc65](https://github.com/vi17250/LSxD/commit/86dbc652b272fe54a949ea0254c9f09c9138ac7d)) - vi17250
+- 🎸 using '-d' make the software recursive - ([f646542](https://github.com/vi17250/LSxD/commit/f6465425819bb8dc25d53be9656f8f6a1411b643)) - vi17250
+- 🎸 lines are displayed in the terminal - ([403aceb](https://github.com/vi17250/LSxD/commit/403aceb1a9ea9c0e73b08acfddcd5b14f1e4249d)) - vi17250
+- 🎸 Sizes are colored by multiples - ([741a271](https://github.com/vi17250/LSxD/commit/741a271d80589a447fd8261fc3074bc2e96ae18c)) - vi17250
+- 🎸 display files - ([97565be](https://github.com/vi17250/LSxD/commit/97565be516d2650dc4002b9ecfa5177449e0cd16)) - vi17250
+- 🎸 icons for files and dirs - ([81244c6](https://github.com/vi17250/LSxD/commit/81244c6dbc8884284d848ba4fac90f2964aef008)) - vi17250
+- 🎸 recursively browse directories - ([3ec8bf9](https://github.com/vi17250/LSxD/commit/3ec8bf99f8006b06a35d290cb3e94e628940dd77)) - vi17250
+- 🎸 Create new() method for Directory - ([5a8d315](https://github.com/vi17250/LSxD/commit/5a8d3158a69f22218b605a7d41ea9c4160fed262)) - vi17250
+- 🎸 get directory size - ([4f4171b](https://github.com/vi17250/LSxD/commit/4f4171bc3e3f445a53653ea3523cdf664d0e975a)) - vi17250
+- 🎸 list files - ([87aa23d](https://github.com/vi17250/LSxD/commit/87aa23d12d7bcd637ca150af1d1e11da375438ee)) - vi17250
+- 🎸 human_size is more readable - ([5616ad3](https://github.com/vi17250/LSxD/commit/5616ad367db316e6325efda9629515c3e1566a20)) - vi17250
+- 🎸 display the output in a formatted way - ([0fc87db](https://github.com/vi17250/LSxD/commit/0fc87db8c8a120e6185bebc8cd253c37f455c829)) - vi17250
+
+### 🐛 Bug Fixes
+
+- 🐛 Each line knows it's type (file or directory) - ([da9879b](https://github.com/vi17250/LSxD/commit/da9879be783d67e5e755499cd8f64f3eaaf60e1a)) - vi17250
+- 🐛 parse files with white spaces and year - ([0990d1a](https://github.com/vi17250/LSxD/commit/0990d1a9a675fc00e569f9032e478e917593f928)) - vi17250
+- 🐛 data are represented via structures - ([55fd666](https://github.com/vi17250/LSxD/commit/55fd666deb3fa9a1358776917234c141305fb419)) - vi17250
+- 🐛 remove useless import - ([3e52038](https://github.com/vi17250/LSxD/commit/3e520380ee3d5a2dfce16618cccbcbd4d3b042af)) - vi17250
+- 🐛 Entity can be a directory or a file - ([ceb7f27](https://github.com/vi17250/LSxD/commit/ceb7f27f20b90d88350e91f0514b2b25bebbb435)) - vi17250
+- 🐛 remove useless code - ([6571a32](https://github.com/vi17250/LSxD/commit/6571a320cc8a0bdb3b7211219e80243f6d3f94c8)) - vi17250
+- 🐛 debug result - ([71ffc85](https://github.com/vi17250/LSxD/commit/71ffc8553815abead8c157d2db3087a636358624)) - vi17250
+
+### 🚜 Refactor
+
+- 💡a line is a vector of tuple - ([265b2ea](https://github.com/vi17250/LSxD/commit/265b2eaa23876f56bdd69af8b865fcfb871c6b16)) - vi17250
+- 💡 remove useless imports - ([f29ce46](https://github.com/vi17250/LSxD/commit/f29ce4661825a10c11f59ba702b019502dcaeca0)) - vi17250
+- 💡 remove useless lifetime parameter - ([3e53dcf](https://github.com/vi17250/LSxD/commit/3e53dcf07da4011cf6c50baa89b90a76ed25785c)) - vi17250
+- 💡 Colored trait applies colors to &str - ([bd5423d](https://github.com/vi17250/LSxD/commit/bd5423d9a12fc80e224300ffcfbcfc991ad61165)) - vi17250
+- 💡 wording colored -> coloring - ([b0ab1eb](https://github.com/vi17250/LSxD/commit/b0ab1eb0eb5901b5c01b1110b364a27418d66679)) - vi17250
+- 💡 commands are in a separate file - ([de5318d](https://github.com/vi17250/LSxD/commit/de5318d2e22a55258af8fbcdf30f7d71732a5d31)) - vi17250
+- 💡 folder structure - ([d0535c7](https://github.com/vi17250/LSxD/commit/d0535c702f4c0d6a31c14d908b630b6007054d63)) - vi17250
+- 💡 remove useless code - ([b3e7399](https://github.com/vi17250/LSxD/commit/b3e73994de5c93ebbf0290835711895d3f26dbd0)) - vi17250
+- 💡 get_dir is a command - ([ef109aa](https://github.com/vi17250/LSxD/commit/ef109aa4fcb4bcaebf5d877258ee3379881aa035)) - vi17250
+- 💡 provides functions to list entities and sizes - ([255e351](https://github.com/vi17250/LSxD/commit/255e351dfd6f6f17391737b532dffb179f6c05f9)) - vi17250
+
+### 📚 Documentation
+
+- ✏️ software punchine - ([170c49b](https://github.com/vi17250/LSxD/commit/170c49b13904114ccae46d63c1157941c4f068c3)) - vi17250
+- ✏️ Update project Name - ([ba8e6db](https://github.com/vi17250/LSxD/commit/ba8e6db7dc2a8b162594831142164474c119195d)) - vi17250
+- ✏️ Cargo manifest gives project informations - ([8bf157c](https://github.com/vi17250/LSxD/commit/8bf157ceed8a34c797716e344df304cde8766e6c)) - vi17250
+- ✏️ Be patient - ([f65d928](https://github.com/vi17250/LSxD/commit/f65d9284800b397f02a6744ba06cfbc7adfc1b6a)) - vi17250
+- ✏️ add key features - ([159a299](https://github.com/vi17250/LSxD/commit/159a2992924dbcc086209381afea9c42f34950a3)) - vi17250
+- ✏️ add screenshots - ([20bf943](https://github.com/vi17250/LSxD/commit/20bf94336481966387b497b219fa67b4d38a1099)) - Victor
+- ✏️ limitation - ([fa264b2](https://github.com/vi17250/LSxD/commit/fa264b2d6d796aa7c52a7fd41d8d7bde7c454bbb)) - Victor
+- ✏️ height of screenshots - ([4622dc2](https://github.com/vi17250/LSxD/commit/4622dc2c4bc8dd78ad3e55b8faa49d9e0a26b638)) - vi17250
+
+### 🧪 Testing
+
+- 💍 command file check all possibilities - ([402cc52](https://github.com/vi17250/LSxD/commit/402cc526ce70ba9133e3d211a2a2128ed18e0267)) - vi17250
+
+### ⚙️ Miscellaneous Tasks
+
+- 🤖 Initial commit - ([8e476d4](https://github.com/vi17250/LSxD/commit/8e476d4e8e227377b6786521e651e80bf80565e7)) - vi17250
+- 🤖 changelog generation - ([7837cc9](https://github.com/vi17250/LSxD/commit/7837cc936ee178f5f5c882a3163f910d82d71411)) - vi17250
+- 🤖 disable warning for tests - ([df14afd](https://github.com/vi17250/LSxD/commit/df14afdecc212f59db108721ddf8121f61ddf1d6)) - vi17250
+- 🤖 the name is now lsxd (lowercase) - ([9deb412](https://github.com/vi17250/LSxD/commit/9deb41272389b6f36edfa1c175932ed52ce5b7a4)) - vi17250
+- 🎡 release-plz - ([f17b7ed](https://github.com/vi17250/LSxD/commit/f17b7edc2ccb6aac34091a38afed5fb15092ccf8)) - vi17250
+
+<!-- generated by git-cliff -->
+---
 ## [unreleased]
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
 dependencies = [
  "anstream",
  "anstyle",
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -218,9 +218,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION



## 🤖 New release

* `lsxd`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0] - 2025-07-31

### 🚀 Features

- 🎸 list directories - ([86dbc65](https://github.com/vi17250/LSxD/commit/86dbc652b272fe54a949ea0254c9f09c9138ac7d)) - vi17250
- 🎸 using '-d' make the software recursive - ([f646542](https://github.com/vi17250/LSxD/commit/f6465425819bb8dc25d53be9656f8f6a1411b643)) - vi17250
- 🎸 lines are displayed in the terminal - ([403aceb](https://github.com/vi17250/LSxD/commit/403aceb1a9ea9c0e73b08acfddcd5b14f1e4249d)) - vi17250
- 🎸 Sizes are colored by multiples - ([741a271](https://github.com/vi17250/LSxD/commit/741a271d80589a447fd8261fc3074bc2e96ae18c)) - vi17250
- 🎸 display files - ([97565be](https://github.com/vi17250/LSxD/commit/97565be516d2650dc4002b9ecfa5177449e0cd16)) - vi17250
- 🎸 icons for files and dirs - ([81244c6](https://github.com/vi17250/LSxD/commit/81244c6dbc8884284d848ba4fac90f2964aef008)) - vi17250
- 🎸 recursively browse directories - ([3ec8bf9](https://github.com/vi17250/LSxD/commit/3ec8bf99f8006b06a35d290cb3e94e628940dd77)) - vi17250
- 🎸 Create new() method for Directory - ([5a8d315](https://github.com/vi17250/LSxD/commit/5a8d3158a69f22218b605a7d41ea9c4160fed262)) - vi17250
- 🎸 get directory size - ([4f4171b](https://github.com/vi17250/LSxD/commit/4f4171bc3e3f445a53653ea3523cdf664d0e975a)) - vi17250
- 🎸 list files - ([87aa23d](https://github.com/vi17250/LSxD/commit/87aa23d12d7bcd637ca150af1d1e11da375438ee)) - vi17250
- 🎸 human_size is more readable - ([5616ad3](https://github.com/vi17250/LSxD/commit/5616ad367db316e6325efda9629515c3e1566a20)) - vi17250
- 🎸 display the output in a formatted way - ([0fc87db](https://github.com/vi17250/LSxD/commit/0fc87db8c8a120e6185bebc8cd253c37f455c829)) - vi17250

### 🐛 Bug Fixes

- 🐛 Each line knows it's type (file or directory) - ([da9879b](https://github.com/vi17250/LSxD/commit/da9879be783d67e5e755499cd8f64f3eaaf60e1a)) - vi17250
- 🐛 parse files with white spaces and year - ([0990d1a](https://github.com/vi17250/LSxD/commit/0990d1a9a675fc00e569f9032e478e917593f928)) - vi17250
- 🐛 data are represented via structures - ([55fd666](https://github.com/vi17250/LSxD/commit/55fd666deb3fa9a1358776917234c141305fb419)) - vi17250
- 🐛 remove useless import - ([3e52038](https://github.com/vi17250/LSxD/commit/3e520380ee3d5a2dfce16618cccbcbd4d3b042af)) - vi17250
- 🐛 Entity can be a directory or a file - ([ceb7f27](https://github.com/vi17250/LSxD/commit/ceb7f27f20b90d88350e91f0514b2b25bebbb435)) - vi17250
- 🐛 remove useless code - ([6571a32](https://github.com/vi17250/LSxD/commit/6571a320cc8a0bdb3b7211219e80243f6d3f94c8)) - vi17250
- 🐛 debug result - ([71ffc85](https://github.com/vi17250/LSxD/commit/71ffc8553815abead8c157d2db3087a636358624)) - vi17250

### 🚜 Refactor

- 💡a line is a vector of tuple - ([265b2ea](https://github.com/vi17250/LSxD/commit/265b2eaa23876f56bdd69af8b865fcfb871c6b16)) - vi17250
- 💡 remove useless imports - ([f29ce46](https://github.com/vi17250/LSxD/commit/f29ce4661825a10c11f59ba702b019502dcaeca0)) - vi17250
- 💡 remove useless lifetime parameter - ([3e53dcf](https://github.com/vi17250/LSxD/commit/3e53dcf07da4011cf6c50baa89b90a76ed25785c)) - vi17250
- 💡 Colored trait applies colors to &str - ([bd5423d](https://github.com/vi17250/LSxD/commit/bd5423d9a12fc80e224300ffcfbcfc991ad61165)) - vi17250
- 💡 wording colored -> coloring - ([b0ab1eb](https://github.com/vi17250/LSxD/commit/b0ab1eb0eb5901b5c01b1110b364a27418d66679)) - vi17250
- 💡 commands are in a separate file - ([de5318d](https://github.com/vi17250/LSxD/commit/de5318d2e22a55258af8fbcdf30f7d71732a5d31)) - vi17250
- 💡 folder structure - ([d0535c7](https://github.com/vi17250/LSxD/commit/d0535c702f4c0d6a31c14d908b630b6007054d63)) - vi17250
- 💡 remove useless code - ([b3e7399](https://github.com/vi17250/LSxD/commit/b3e73994de5c93ebbf0290835711895d3f26dbd0)) - vi17250
- 💡 get_dir is a command - ([ef109aa](https://github.com/vi17250/LSxD/commit/ef109aa4fcb4bcaebf5d877258ee3379881aa035)) - vi17250
- 💡 provides functions to list entities and sizes - ([255e351](https://github.com/vi17250/LSxD/commit/255e351dfd6f6f17391737b532dffb179f6c05f9)) - vi17250

### 📚 Documentation

- ✏️ software punchine - ([170c49b](https://github.com/vi17250/LSxD/commit/170c49b13904114ccae46d63c1157941c4f068c3)) - vi17250
- ✏️ Update project Name - ([ba8e6db](https://github.com/vi17250/LSxD/commit/ba8e6db7dc2a8b162594831142164474c119195d)) - vi17250
- ✏️ Cargo manifest gives project informations - ([8bf157c](https://github.com/vi17250/LSxD/commit/8bf157ceed8a34c797716e344df304cde8766e6c)) - vi17250
- ✏️ Be patient - ([f65d928](https://github.com/vi17250/LSxD/commit/f65d9284800b397f02a6744ba06cfbc7adfc1b6a)) - vi17250
- ✏️ add key features - ([159a299](https://github.com/vi17250/LSxD/commit/159a2992924dbcc086209381afea9c42f34950a3)) - vi17250
- ✏️ add screenshots - ([20bf943](https://github.com/vi17250/LSxD/commit/20bf94336481966387b497b219fa67b4d38a1099)) - Victor
- ✏️ limitation - ([fa264b2](https://github.com/vi17250/LSxD/commit/fa264b2d6d796aa7c52a7fd41d8d7bde7c454bbb)) - Victor
- ✏️ height of screenshots - ([4622dc2](https://github.com/vi17250/LSxD/commit/4622dc2c4bc8dd78ad3e55b8faa49d9e0a26b638)) - vi17250

### 🧪 Testing

- 💍 command file check all possibilities - ([402cc52](https://github.com/vi17250/LSxD/commit/402cc526ce70ba9133e3d211a2a2128ed18e0267)) - vi17250

### ⚙️ Miscellaneous Tasks

- 🤖 Initial commit - ([8e476d4](https://github.com/vi17250/LSxD/commit/8e476d4e8e227377b6786521e651e80bf80565e7)) - vi17250
- 🤖 changelog generation - ([7837cc9](https://github.com/vi17250/LSxD/commit/7837cc936ee178f5f5c882a3163f910d82d71411)) - vi17250
- 🤖 disable warning for tests - ([df14afd](https://github.com/vi17250/LSxD/commit/df14afdecc212f59db108721ddf8121f61ddf1d6)) - vi17250
- 🤖 the name is now lsxd (lowercase) - ([9deb412](https://github.com/vi17250/LSxD/commit/9deb41272389b6f36edfa1c175932ed52ce5b7a4)) - vi17250
- 🎡 release-plz - ([f17b7ed](https://github.com/vi17250/LSxD/commit/f17b7edc2ccb6aac34091a38afed5fb15092ccf8)) - vi17250
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).