### PR TITLE
chore: release v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,22 +43,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -113,7 +113,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -240,12 +240,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -254,14 +269,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -271,10 +303,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -283,10 +327,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -295,10 +351,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -307,7 +375,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"


### PR DESCRIPTION



## 🤖 New release

* `lsxd`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0] - 2025-08-04

### 🚀 Features

- 🎸 list directories - ([86dbc65](https://github.com/vi17250/LSxD/commit/86dbc652b272fe54a949ea0254c9f09c9138ac7d)) - vi17250
- 🎸 using '-d' make the software recursive - ([f646542](https://github.com/vi17250/LSxD/commit/f6465425819bb8dc25d53be9656f8f6a1411b643)) - vi17250
- 🎸 lines are displayed in the terminal - ([403aceb](https://github.com/vi17250/LSxD/commit/403aceb1a9ea9c0e73b08acfddcd5b14f1e4249d)) - vi17250
- 🎸 Sizes are colored by multiples - ([741a271](https://github.com/vi17250/LSxD/commit/741a271d80589a447fd8261fc3074bc2e96ae18c)) - vi17250
- 🎸 display files - ([97565be](https://github.com/vi17250/LSxD/commit/97565be516d2650dc4002b9ecfa5177449e0cd16)) - vi17250
- 🎸 icons for files and dirs - ([81244c6](https://github.com/vi17250/LSxD/commit/81244c6dbc8884284d848ba4fac90f2964aef008)) - vi17250
- 🎸 recursively browse directories - ([3ec8bf9](https://github.com/vi17250/LSxD/commit/3ec8bf99f8006b06a35d290cb3e94e628940dd77)) - vi17250
- 🎸 Create new() method for Directory - ([5a8d315](https://github.com/vi17250/LSxD/commit/5a8d3158a69f22218b605a7d41ea9c4160fed262)) - vi17250
- 🎸 get directory size - ([4f4171b](https://github.com/vi17250/LSxD/commit/4f4171bc3e3f445a53653ea3523cdf664d0e975a)) - vi17250
- 🎸 list files - ([87aa23d](https://github.com/vi17250/LSxD/commit/87aa23d12d7bcd637ca150af1d1e11da375438ee)) - vi17250
- 🎸 human_size is more readable - ([5616ad3](https://github.com/vi17250/LSxD/commit/5616ad367db316e6325efda9629515c3e1566a20)) - vi17250
- 🎸 display the output in a formatted way - ([0fc87db](https://github.com/vi17250/LSxD/commit/0fc87db8c8a120e6185bebc8cd253c37f455c829)) - vi17250

### 🐛 Bug Fixes

- 🐛 Each line knows it's type (file or directory) - ([da9879b](https://github.com/vi17250/LSxD/commit/da9879be783d67e5e755499cd8f64f3eaaf60e1a)) - vi17250
- 🐛 parse files with white spaces and year - ([0990d1a](https://github.com/vi17250/LSxD/commit/0990d1a9a675fc00e569f9032e478e917593f928)) - vi17250
- 🐛 data are represented via structures - ([55fd666](https://github.com/vi17250/LSxD/commit/55fd666deb3fa9a1358776917234c141305fb419)) - vi17250
- 🐛 remove useless import - ([3e52038](https://github.com/vi17250/LSxD/commit/3e520380ee3d5a2dfce16618cccbcbd4d3b042af)) - vi17250
- 🐛 Entity can be a directory or a file - ([ceb7f27](https://github.com/vi17250/LSxD/commit/ceb7f27f20b90d88350e91f0514b2b25bebbb435)) - vi17250
- 🐛 remove useless code - ([6571a32](https://github.com/vi17250/LSxD/commit/6571a320cc8a0bdb3b7211219e80243f6d3f94c8)) - vi17250
- 🐛 debug result - ([71ffc85](https://github.com/vi17250/LSxD/commit/71ffc8553815abead8c157d2db3087a636358624)) - vi17250

### 🚜 Refactor

- 💡a line is a vector of tuple - ([265b2ea](https://github.com/vi17250/LSxD/commit/265b2eaa23876f56bdd69af8b865fcfb871c6b16)) - vi17250
- 💡 remove useless imports - ([f29ce46](https://github.com/vi17250/LSxD/commit/f29ce4661825a10c11f59ba702b019502dcaeca0)) - vi17250
- 💡 remove useless lifetime parameter - ([3e53dcf](https://github.com/vi17250/LSxD/commit/3e53dcf07da4011cf6c50baa89b90a76ed25785c)) - vi17250
- 💡 Colored trait applies colors to &str - ([bd5423d](https://github.com/vi17250/LSxD/commit/bd5423d9a12fc80e224300ffcfbcfc991ad61165)) - vi17250
- 💡 wording colored -> coloring - ([b0ab1eb](https://github.com/vi17250/LSxD/commit/b0ab1eb0eb5901b5c01b1110b364a27418d66679)) - vi17250
- 💡 commands are in a separate file - ([de5318d](https://github.com/vi17250/LSxD/commit/de5318d2e22a55258af8fbcdf30f7d71732a5d31)) - vi17250
- 💡 folder structure - ([d0535c7](https://github.com/vi17250/LSxD/commit/d0535c702f4c0d6a31c14d908b630b6007054d63)) - vi17250
- 💡 remove useless code - ([b3e7399](https://github.com/vi17250/LSxD/commit/b3e73994de5c93ebbf0290835711895d3f26dbd0)) - vi17250
- 💡 get_dir is a command - ([ef109aa](https://github.com/vi17250/LSxD/commit/ef109aa4fcb4bcaebf5d877258ee3379881aa035)) - vi17250
- 💡 provides functions to list entities and sizes - ([255e351](https://github.com/vi17250/LSxD/commit/255e351dfd6f6f17391737b532dffb179f6c05f9)) - vi17250

### 📚 Documentation

- ✏️ software punchine - ([170c49b](https://github.com/vi17250/LSxD/commit/170c49b13904114ccae46d63c1157941c4f068c3)) - vi17250
- ✏️ Update project Name - ([ba8e6db](https://github.com/vi17250/LSxD/commit/ba8e6db7dc2a8b162594831142164474c119195d)) - vi17250
- ✏️ Cargo manifest gives project informations - ([8bf157c](https://github.com/vi17250/LSxD/commit/8bf157ceed8a34c797716e344df304cde8766e6c)) - vi17250
- ✏️ Be patient - ([f65d928](https://github.com/vi17250/LSxD/commit/f65d9284800b397f02a6744ba06cfbc7adfc1b6a)) - vi17250
- ✏️ add key features - ([159a299](https://github.com/vi17250/LSxD/commit/159a2992924dbcc086209381afea9c42f34950a3)) - vi17250
- ✏️ add screenshots - ([20bf943](https://github.com/vi17250/LSxD/commit/20bf94336481966387b497b219fa67b4d38a1099)) - Victor
- ✏️ limitation - ([fa264b2](https://github.com/vi17250/LSxD/commit/fa264b2d6d796aa7c52a7fd41d8d7bde7c454bbb)) - Victor

### 🧪 Testing

- 💍 command file check all possibilities - ([402cc52](https://github.com/vi17250/LSxD/commit/402cc526ce70ba9133e3d211a2a2128ed18e0267)) - vi17250

### ⚙️ Miscellaneous Tasks

- 🤖 Initial commit - ([8e476d4](https://github.com/vi17250/LSxD/commit/8e476d4e8e227377b6786521e651e80bf80565e7)) - vi17250
- 🤖 changelog generation - ([7837cc9](https://github.com/vi17250/LSxD/commit/7837cc936ee178f5f5c882a3163f910d82d71411)) - vi17250
- 🤖 disable warning for tests - ([df14afd](https://github.com/vi17250/LSxD/commit/df14afdecc212f59db108721ddf8121f61ddf1d6)) - vi17250
- 🤖 the name is now lsxd (lowercase) - ([9deb412](https://github.com/vi17250/LSxD/commit/9deb41272389b6f36edfa1c175932ed52ce5b7a4)) - vi17250
- 🎡 release-plz - ([f17b7ed](https://github.com/vi17250/LSxD/commit/f17b7edc2ccb6aac34091a38afed5fb15092ccf8)) - vi17250
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).